### PR TITLE
fix: Add missing account section Payment

### DIFF
--- a/gsbparse/account_file.py
+++ b/gsbparse/account_file.py
@@ -14,6 +14,7 @@ from gsbparse.account_section import (
     GsbSectionCurrency,
     GsbSectionFinancial_year,
     GsbSectionParty,
+    GsbSectionPayment,
     GsbSectionReconcile,
     GsbSectionSubBudgetary,
     GsbSectionSubCategory,
@@ -82,6 +83,9 @@ class AccountFile:
         sections["Reconcile"] = GsbSectionReconcile(
             [child.attrib for child in root if child.tag == "Reconcile"]
         )
+        sections["Payment"] = GsbSectionPayment(
+            [child.attrib for child in root if child.tag == "Payment"]
+        )
 
         return sections
 
@@ -134,3 +138,8 @@ class AccountFile:
     def reconcile(self) -> pd.DataFrame:
         """Return records of the Reconcile section as a pd.DataFrame."""
         return self.sections["Reconcile"].df
+
+    @cached_property
+    def payment(self) -> pd.DataFrame:
+        """Return records of the Payment section as a pd.DataFrame."""
+        return self.sections["Payment"].df

--- a/gsbparse/account_section.py
+++ b/gsbparse/account_section.py
@@ -80,7 +80,7 @@ class AccountSection(metaclass=ABCMeta):
 
         if self._int_cols:
             df[self._int_cols] = df[self._int_cols].apply(
-                pd.to_numeric, downcast="integer"
+                pd.to_numeric, downcast="integer", errors="coerce"
             )
 
         if self._bool_cols:

--- a/gsbparse/account_section.py
+++ b/gsbparse/account_section.py
@@ -402,10 +402,10 @@ class GsbSectionPayment(AccountSection):
         """Build self.df from the list of XML tags attributes values.
 
         Args:
-            XML_tags_attributes_values (list(dict)): Values of "Transaction"
+            XML_tags_attributes_values (list(dict)): Values of "Payment"
                 tags attributes.
         """
-        super(GsbSectionTransaction, self).__init__(XML_tags_attributes_values)
+        super(GsbSectionPayment, self).__init__(XML_tags_attributes_values)
 
 
 class GsbSectionFinancial_year(AccountSection):
@@ -437,7 +437,7 @@ class GsbSectionFinancial_year(AccountSection):
         """Build self.df from the list of XML tags attributes values.
 
         Args:
-            XML_tags_attributes_values (list(dict)): Values of "Transaction"
+            XML_tags_attributes_values (list(dict)): Values of "Financial_year"
                 tags attributes.
         """
         super(GsbSectionFinancial_year, self).__init__(XML_tags_attributes_values)
@@ -476,7 +476,7 @@ class GsbSectionReconcile(AccountSection):
         """Build self.df from the list of XML tags attributes values.
 
         Args:
-            XML_tags_attributes_values (list(dict)): Values of "Transaction"
+            XML_tags_attributes_values (list(dict)): Values of "Reconcile"
                 tags attributes.
         """
         super(GsbSectionReconcile, self).__init__(XML_tags_attributes_values)


### PR DESCRIPTION
Hello,

I recently discovered your project, and found that the Payment section was missing (not finished).

This PR adds the missing parts to be able to read payments values.

I removed the `Current_number` column from integer ones because it defaults to `(null)` when th payment has never been used.